### PR TITLE
Adds support for bolt's --no-ssl option [DON'T MERGE WITHOUT DISCUSSION]

### DIFF
--- a/contents/bolt-executor
+++ b/contents/bolt-executor
@@ -5,6 +5,8 @@ import os
 import subprocess
 import sys
 
+os.putenv("HOME", "/var/lib/rundeck")
+os.putenv("PATH", "PATH=/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin")
 
 parser = argparse.ArgumentParser(description='Run Bolt command.')
 parser.add_argument('username', help='the username')
@@ -26,7 +28,7 @@ if "RD_CONFIG_PASSWORD_STORAGE_PATH" in os.environ:
 if protocol == "ssh":
     COMMAND.append("--tty")
 
-if use_ssl != true:
+if use_ssl != "true":
 	COMMAND.append("--no-ssl")
 
 if os.getenv("RD_JOB_LOGLEVEL") == "DEBUG":

--- a/contents/bolt-executor
+++ b/contents/bolt-executor
@@ -15,6 +15,7 @@ exec_command = os.getenv("RD_EXEC_COMMAND")
 
 protocol = os.getenv("RD_CONFIG_PROTOCOL") 
 host=protocol +"://"+args.hostname
+use_ssl = os.getenv("RD_CONFIG_WINRM_SSL")
 
 COMMAND = ["/usr/local/bin/bolt", "command", "run", exec_command,"-n", host,"-u",args.username]
 
@@ -24,6 +25,9 @@ if "RD_CONFIG_PASSWORD_STORAGE_PATH" in os.environ:
 
 if protocol == "ssh":
     COMMAND.append("--tty")
+
+if use_ssl != true:
+	COMMAND.append("--no-ssl")
 
 if os.getenv("RD_JOB_LOGLEVEL") == "DEBUG":
     COMMAND.append("--debug")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -41,6 +41,14 @@ providers:
             storage-path-root: "keys"
             storage-file-meta-filter: "Rundeck-data-type=password"
             instance-scope-node-attribute: "bolt-password-storage-path"
+        - type: Boolean
+          name: winrm_ssl
+          title: Use SSL for WinRM
+          description: Enable SSL requirement for WinRM
+          default: true
+          scope: Instance
+          renderingOptions:
+             instance-scope-node-attribute: "bolt-winrm-ssl"      
     - name: bolt-file-copier
       service: FileCopier
       title: 'Puppet Bolt / File Copier'
@@ -73,3 +81,11 @@ providers:
             storage-path-root: "keys"
             storage-file-meta-filter: "Rundeck-data-type=password"
             instance-scope-node-attribute: "bolt-password-storage-path"
+        - type: Boolean
+          name: winrm_ssl
+          title: Use SSL for WinRM
+          description: Enable SSL requirement for WinRM
+          default: true
+          scope: Instance
+          renderingOptions:
+             instance-scope-node-attribute: "bolt-winrm-ssl"           

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,7 +2,7 @@ name: Bolt node execution services
 rundeckPluginVersion: 1.2
 author: Luis Toledo
 date: 10/17/2017
-version: 1.0
+version: 1.0.1
 providers:
     - name: bolt-executor
       service: NodeExecutor


### PR DESCRIPTION
Hi there!

So at a core level, this adds support for bolt's no-ssl option, and that part works out great.

The reason why I'm requesting discussion before you consider merging it is --  I had to add HOME and PATH to the environment for bolt 1.2.0 to function correctly.  Both of those settings I put are based off my install (Which should be pretty standard, but still).  If you are comfortable with those being in there as-is, then feel free to merge.  However, I wonder if there's some better way to handle it than what I did.  Why it doesn't get HOME and PATH from the parent environment is beyond me.  I also don't know if there is a way to actually pull the HOME and PATH via RD_ variables and just pass them along.

Either way, this is working great for me as is so I can confirm it functions on a RHEL 7 based rundeck server.